### PR TITLE
Feat: Implement Phase 1 of JSON-driven AppzInputField

### DIFF
--- a/assets/ui_config.json
+++ b/assets/ui_config.json
@@ -1,0 +1,33 @@
+{
+  "default": {
+    "borderColor": "#D9D9D9",
+    "borderRadius": 10,
+    "backgroundColor": "#F6F6F6",
+    "textColor": "#000000",
+    "labelColor": "#333333",
+    "fontFamily": "Inter",
+    "fontSize": 14,
+    "paddingHorizontal": 12,
+    "paddingVertical": 10,
+    "labelFontSize": 12
+  },
+  "focused": {
+    "borderColor": "#3B82F6",
+    "borderWidth": 1.5
+  },
+  "error": {
+    "borderColor": "#EF4444",
+    "textColor": "#EF4444",
+    "labelColor": "#EF4444",
+    "backgroundColor": "#FEECEC"
+  },
+  "disabled": {
+    "borderColor": "#E0E0E0",
+    "backgroundColor": "#EEEEEE",
+    "textColor": "#A0A0A0",
+    "labelColor": "#A0A0A0"
+  },
+  "filled": {
+    "backgroundColor": "#E9E9E9"
+  }
+}

--- a/lib/components/appz_input_field/appz_input_field_enums.dart
+++ b/lib/components/appz_input_field/appz_input_field_enums.dart
@@ -1,0 +1,41 @@
+// Defines enums for controlling the AppzInputField component.
+
+/// Defines the visual and interactive state of the AppzInputField.
+enum AppzFieldState {
+  /// Standard, default interactive state.
+  defaultState,
+
+  /// Indicates the field has content. Visual distinction may vary based on UI config.
+  filled,
+
+  /// Indicates the field currently has input focus.
+  focused,
+
+  /// Indicates the field is not interactive.
+  disabled,
+
+  /// Indicates the field has a validation error.
+  error,
+}
+
+/// Defines the specific type or variant of the AppzInputField.
+/// This determines its structure, behavior, and specific styling aspects.
+enum AppzFieldType {
+  /// A standard single-line text input field.
+  defaultType,
+
+  /// A field for entering an MPIN, typically 4-6 digits in separate boxes.
+  mpin,
+
+  /// A field for entering an Aadhaar number, typically with XXXX XXXX XXXX formatting.
+  aadhaar,
+
+  /// A field for entering a mobile phone number, often with a country code prefix.
+  mobile,
+
+  /// A UI element for initiating a file upload.
+  fileUpload,
+
+  /// A field for displaying or entering longer text descriptions, potentially read-only or auto-resizing.
+  textDescription,
+}

--- a/lib/components/appz_input_field/appz_style_config.dart
+++ b/lib/components/appz_input_field/appz_style_config.dart
@@ -1,0 +1,236 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'appz_input_field_enums.dart';
+
+// Helper function to parse color from hex string
+Color _parseColor(String? hexColor, Color defaultColor) {
+  if (hexColor == null || hexColor.isEmpty) return defaultColor;
+  hexColor = hexColor.toUpperCase().replaceAll("#", "");
+  if (hexColor.length == 6) {
+    hexColor = "FF$hexColor"; // Add alpha if missing
+  }
+  if (hexColor.length == 8) {
+    try {
+      return Color(int.parse(hexColor, radix: 16));
+    } catch (e) {
+      // Fallback to default if parsing fails
+      print("Error parsing color: $hexColor. Error: $e");
+      return defaultColor;
+    }
+  }
+  return defaultColor;
+}
+
+class AppzStateStyle {
+  final Color borderColor;
+  final double borderWidth;
+  final double borderRadius;
+  final Color backgroundColor;
+  final Color textColor;
+  final Color labelColor;
+  final String fontFamily;
+  final double fontSize;
+  final double labelFontSize;
+  final double paddingHorizontal;
+  final double paddingVertical;
+
+  const AppzStateStyle({
+    required this.borderColor,
+    this.borderWidth = 1.0,
+    required this.borderRadius,
+    required this.backgroundColor,
+    required this.textColor,
+    required this.labelColor,
+    required this.fontFamily,
+    required this.fontSize,
+    required this.labelFontSize,
+    required this.paddingHorizontal,
+    required this.paddingVertical,
+  });
+
+  // Factory to create from JSON, merging with a base (default) style
+  factory AppzStateStyle.fromJson(Map<String, dynamic> json, AppzStateStyle baseStyle) {
+    return AppzStateStyle(
+      borderColor: _parseColor(json['borderColor'] as String?, baseStyle.borderColor),
+      borderWidth: (json['borderWidth'] as num?)?.toDouble() ?? baseStyle.borderWidth,
+      borderRadius: (json['borderRadius'] as num?)?.toDouble() ?? baseStyle.borderRadius,
+      backgroundColor: _parseColor(json['backgroundColor'] as String?, baseStyle.backgroundColor),
+      textColor: _parseColor(json['textColor'] as String?, baseStyle.textColor),
+      labelColor: _parseColor(json['labelColor'] as String?, baseStyle.labelColor),
+      fontFamily: json['fontFamily'] as String? ?? baseStyle.fontFamily,
+      fontSize: (json['fontSize'] as num?)?.toDouble() ?? baseStyle.fontSize,
+      labelFontSize: (json['labelFontSize'] as num?)?.toDouble() ?? baseStyle.labelFontSize,
+      paddingHorizontal: (json['paddingHorizontal'] as num?)?.toDouble() ?? baseStyle.paddingHorizontal,
+      paddingVertical: (json['paddingVertical'] as num?)?.toDouble() ?? baseStyle.paddingVertical,
+    );
+  }
+
+  // Creates a style by overriding properties of this style with another one (for merging)
+  AppzStateStylecopyWith(AppzStateStyle? overrideStyle) {
+    if (overrideStyle == null) return this;
+    return AppzStateStyle(
+      borderColor: overrideStyle.borderColor, // Assuming overrideStyle is already resolved from JSON
+      borderWidth: overrideStyle.borderWidth,
+      borderRadius: overrideStyle.borderRadius,
+      backgroundColor: overrideStyle.backgroundColor,
+      textColor: overrideStyle.textColor,
+      labelColor: overrideStyle.labelColor,
+      fontFamily: overrideStyle.fontFamily,
+      fontSize: overrideStyle.fontSize,
+      labelFontSize: overrideStyle.labelFontSize,
+      paddingHorizontal: overrideStyle.paddingHorizontal,
+      paddingVertical: overrideStyle.paddingVertical,
+    );
+  }
+}
+
+class AppzStyleConfig {
+  AppzStyleConfig._privateConstructor();
+  static final AppzStyleConfig _instance = AppzStyleConfig._privateConstructor();
+  static AppzStyleConfig get instance => _instance;
+
+  bool _isInitialized = false;
+  bool get isInitialized => _isInitialized;
+
+  late AppzStateStyle _defaultStyle;
+  Map<String, Map<String, dynamic>> _rawJsonStyles = {}; // To store the raw JSON for merging
+
+  // Hardcoded fallback default style
+  static final AppzStateStyle _fallbackDefaultStyle = AppzStateStyle(
+    borderColor: _parseColor("#D9D9D9", Colors.grey),
+    borderWidth: 1.0,
+    borderRadius: 10.0,
+    backgroundColor: _parseColor("#F6F6F6", Colors.grey[200]!),
+    textColor: _parseColor("#000000", Colors.black),
+    labelColor: _parseColor("#333333", Colors.black87),
+    fontFamily: "Inter",
+    fontSize: 14.0,
+    labelFontSize: 12.0,
+    paddingHorizontal: 12.0,
+    paddingVertical: 10.0,
+  );
+
+  Future<void> load(String assetPath) async {
+    if (_isInitialized) return;
+
+    try {
+      final String jsonString = await rootBundle.loadString(assetPath);
+      _rawJsonStyles = Map<String, Map<String, dynamic>>.from(json.decode(jsonString) as Map);
+
+      // Initialize _defaultStyle from JSON or fallback
+      final defaultJson = _rawJsonStyles['default'];
+      if (defaultJson != null) {
+        _defaultStyle = AppzStateStyle.fromJson(defaultJson, _fallbackDefaultStyle); // Base fallback for default itself
+      } else {
+        print("Warning: 'default' style not found in ui_config.json. Using hardcoded fallback default style.");
+        _defaultStyle = _fallbackDefaultStyle;
+      }
+      _isInitialized = true;
+      print("AppzStyleConfig loaded successfully from $assetPath.");
+    } catch (e) {
+      print("Error loading UI config from $assetPath: $e. Using hardcoded fallback default style for all states.");
+      _defaultStyle = _fallbackDefaultStyle; // Use fallback if any error occurs
+      _rawJsonStyles = {}; // Clear raw styles to ensure fallback is used consistently
+      _isInitialized = true;
+    }
+  }
+
+  AppzStateStyle _getRawStyleForStateName(String stateName) {
+    final stateJson = _rawJsonStyles[stateName];
+    if (stateJson != null) {
+      // When creating a style for a specific state (e.g., "focused"),
+      // it should use the fully resolved "_defaultStyle" as its base for merging.
+      return AppzStateStyle.fromJson(stateJson, _defaultStyle);
+    }
+    // If the specific state (e.g. "focused") is not in JSON, it fully inherits from default.
+    return _defaultStyle;
+  }
+
+  AppzStateStyle getStyleForState(AppzFieldState state, {bool isFilled = false}) {
+    if (!_isInitialized) {
+      print("Warning: AppzStyleConfig not initialized or load failed. Returning complete fallback style.");
+      return _fallbackDefaultStyle;
+    }
+
+    AppzStateStyle currentStyle;
+
+    switch (state) {
+      case AppzFieldState.defaultState:
+        currentStyle = _defaultStyle;
+        break;
+      case AppzFieldState.focused:
+        currentStyle = _getRawStyleForStateName('focused');
+        break;
+      case AppzFieldState.error:
+        currentStyle = _getRawStyleForStateName('error');
+        break;
+      case AppzFieldState.disabled:
+        currentStyle = _getRawStyleForStateName('disabled');
+        break;
+      case AppzFieldState.filled:
+        // 'filled' state might primarily inherit from default, but can have overrides
+        currentStyle = _getRawStyleForStateName('filled');
+        break;
+      default:
+        currentStyle = _defaultStyle;
+    }
+
+    // If the field is filled, and there's a specific "filled" configuration,
+    // let its background override the current state's background if it's different from default.
+    // This logic might need refinement based on desired behavior.
+    if (isFilled) {
+        final filledStyleOverrides = _rawJsonStyles['filled'];
+        if (filledStyleOverrides != null && filledStyleOverrides['backgroundColor'] != null) {
+             final filledBgColor = _parseColor(filledStyleOverrides['backgroundColor'] as String?, currentStyle.backgroundColor);
+             if (filledBgColor != currentStyle.backgroundColor) { // Only override if different
+                return currentStyle.copyWith(
+                  backgroundColor: filledBgColor
+                );
+             }
+        } else if (filledStyleOverrides != null) {
+            // If 'filled' exists but doesn't specify a background, it might mean other properties
+            // This simply merges all 'filled' properties over the current state's style.
+            AppzStateStyle tempFilledStyle = AppzStateStyle.fromJson(filledStyleOverrides, currentStyle);
+            return currentStyle.copyWith(tempFilledStyle);
+
+        }
+    }
+    return currentStyle;
+  }
+
+   // Helper to create a copy of AppzStateStyle with some properties overridden
+   // This is not used directly by AppzStateStyle.fromJson but can be useful externally if needed.
+}
+
+// Extension on AppzStateStyle to provide a copyWith method, if needed for more granular updates outside of fromJson.
+// However, the current fromJson handles merging from a base, and getStyleForState handles state-specific overrides.
+extension AppzStateStyleCopyWith on AppzStateStyle {
+  AppzStateStyle copyWith({
+    Color? borderColor,
+    double? borderWidth,
+    double? borderRadius,
+    Color? backgroundColor,
+    Color? textColor,
+    Color? labelColor,
+    String? fontFamily,
+    double? fontSize,
+    double? labelFontSize,
+    double? paddingHorizontal,
+    double? paddingVertical,
+  }) {
+    return AppzStateStyle(
+      borderColor: borderColor ?? this.borderColor,
+      borderWidth: borderWidth ?? this.borderWidth,
+      borderRadius: borderRadius ?? this.borderRadius,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      textColor: textColor ?? this.textColor,
+      labelColor: labelColor ?? this.labelColor,
+      fontFamily: fontFamily ?? this.fontFamily,
+      fontSize: fontSize ?? this.fontSize,
+      labelFontSize: labelFontSize ?? this.labelFontSize,
+      paddingHorizontal: paddingHorizontal ?? this.paddingHorizontal,
+      paddingVertical: paddingVertical ?? this.paddingVertical,
+    );
+  }
+}

--- a/main.dart
+++ b/main.dart
@@ -1,7 +1,16 @@
 import 'package:flutter/material.dart';
-import 'example/appz_input_field_example_page.dart'; // Adjust path if your structure is different
+// Adjust import paths as per your project structure
+import 'example/appz_input_field_example_page.dart';
+import 'lib/components/appz_input_field/appz_style_config.dart';
 
-void main() {
+Future<void> main() async {
+  // Ensure that widget binding is initialized before calling native code.
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Load the UI configuration
+  // It's important to await this before runApp so styles are ready.
+  await AppzStyleConfig.instance.load('assets/ui_config.json');
+
   runApp(const MyApp());
 }
 
@@ -11,13 +20,15 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'AppzInputField Demo',
+      title: 'AppzInputField Demo V2',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
-        // You might want to define some base text styles or color schemes
-        // that your AppzInputField might inherit or use as fallbacks later.
+        // You might want to define some base app theme properties here.
+        // For now, AppzInputField is self-contained with its styling via JSON.
+        // colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
+        useMaterial3: true,
       ),
       home: const AppzInputFieldExamplePage(),
+      debugShowCheckedModeBanner: false, // Optional: to hide the debug banner
     );
   }
 }


### PR DESCRIPTION
- Set up project structure for the new AppzInputField library.
- Defined core enums: `AppzFieldState` and `AppzFieldType`.
- Implemented `AppzStyleConfig` singleton to load, parse, and manage UI styles from `assets/ui_config.json`.
  - Includes default fallback styles and inheritance from a base 'default' JSON configuration.
- Refactored `AppzInputField` core with robust state management for field states (default, filled, focused, disabled, error) based on interaction and validation.
- Implemented rendering for `AppzFieldType.defaultType`, dynamically applying styles (borders, colors, fonts, padding) from `AppzStyleConfig`.
- Updated the example page to showcase `defaultType` with various states, demonstrating the JSON-driven styling.
- Configured `main.dart` to load `AppzStyleConfig` at application startup.