### PR TITLE
Fix: Add diagnostics for disabled state in AppzInputField

### DIFF
--- a/lib/components/appz_input_field/appz_input_field.dart
+++ b/lib/components/appz_input_field/appz_input_field.dart
@@ -210,6 +210,10 @@ class _AppzInputFieldState extends State<AppzInputField> {
     }
 
     // Determine the actual state to pass for styling, considering focus separately for border
+
+    // DEBUG PRINT:
+    print("DEBUG AppzInputField build: currentFieldState = $_currentFieldState, isEffectivelyDisabled = $_isEffectivelyDisabled, initialFieldState = ${widget.initialFieldState}, isFocused = $_isFocused, hasError = $_hasError, isFilled = $_isFilled, controllerText = '${_internalController.text}'");
+
     AppzFieldState stateForStyle = _currentFieldState;
     if (_isFocused && !_hasError && !_isEffectivelyDisabled) {
         // If focused without error/disabled, use 'focused' for style lookup


### PR DESCRIPTION
- Added a debug print statement in the build method of AppzInputField to output current state variables, aiding in diagnosing issues with the disabled state.
- Verified that the `TextFormField` for `defaultType` correctly uses `enabled: !_isEffectivelyDisabled`.

The primary fix for any non-functional disabled state would involve ensuring `_currentFieldState` is correctly set to `AppzFieldState.disabled` when intended, which the print statement will help verify.