### PR TITLE
Feat: Implement Mobile, Aadhaar, and MPIN field types (Phase 2)

### DIFF
--- a/example/appz_input_field_example_page.dart
+++ b/example/appz_input_field_example_page.dart
@@ -18,6 +18,9 @@ class _AppzInputFieldExamplePageState extends State<AppzInputFieldExamplePage> {
   final _passwordController = TextEditingController();
   final _disabledController = TextEditingController(text: "Disabled Text");
   final _errorController = TextEditingController();
+  final _mobileController = TextEditingController();
+  final _aadhaarController = TextEditingController();
+  final _mpinController = TextEditingController();
 
   final _formKey = GlobalKey<FormState>();
 
@@ -29,6 +32,9 @@ class _AppzInputFieldExamplePageState extends State<AppzInputFieldExamplePage> {
     _passwordController.dispose();
     _disabledController.dispose();
     _errorController.dispose();
+    _mobileController.dispose();
+    _aadhaarController.dispose();
+    _mpinController.dispose(); // Added this line
     super.dispose();
   }
 
@@ -115,6 +121,43 @@ class _AppzInputFieldExamplePageState extends State<AppzInputFieldExamplePage> {
                 fieldType: AppzFieldType.defaultType,
                 initialFieldState: AppzFieldState.error, // Forcing error state appearance initially
                 validator: (value) => 'This is a validation error message.', // Ensures error state persists
+              ),
+              const SizedBox(height: 20),
+
+              const Text("Mobile Number Input (+91 prefix, 10 digits):", style: TextStyle(fontWeight: FontWeight.bold)),
+              AppzInputField(
+                label: 'Mobile Number',
+                hintText: '00000 00000',
+                controller: _mobileController,
+                fieldType: AppzFieldType.mobile,
+                validationType: AppzInputValidationType.mandatory, // To make it required
+                // Internal validator in AppzInputField for mobile handles 10-digit check
+              ),
+              const SizedBox(height: 20),
+
+              const Text("Aadhaar Input (XXXX XXXX XXXX):", style: TextStyle(fontWeight: FontWeight.bold)),
+              AppzInputField(
+                label: 'Aadhaar Number',
+                // hintText: 'Enter 12-digit Aadhaar', // Default hint is XXXX XXXX XXXX
+                controller: _aadhaarController,
+                fieldType: AppzFieldType.aadhaar,
+                validationType: AppzInputValidationType.mandatory,
+              ),
+              const SizedBox(height: 20),
+
+              const Text("MPIN Input (Default 4 digits, Obscured):", style: TextStyle(fontWeight: FontWeight.bold)),
+              AppzInputField(
+                label: 'Enter MPIN',
+                controller: _mpinController,
+                fieldType: AppzFieldType.mpin,
+                obscureText: true,
+                // mpinLength: 4, // Default is 4
+                validationType: AppzInputValidationType.mandatory,
+                validator: (value) { // Example of custom validation for MPIN length
+                  if (value == null || value.isEmpty) return 'MPIN is required.';
+                  if (value.length != 4) return 'MPIN must be 4 digits.'; // Use widget.mpinLength if it were accessible here or passed
+                  return null;
+                },
               ),
               const SizedBox(height: 30),
 

--- a/lib/components/appz_input_field/formatters/aadhaar_input_formatter.dart
+++ b/lib/components/appz_input_field/formatters/aadhaar_input_formatter.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/services.dart';
+
+class AadhaarInputFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    // Get the new text and remove any non-digit characters
+    String newText = newValue.text.replaceAll(RegExp(r'[^0-9]'), '');
+
+    // If the new text is longer than 12 digits, truncate it
+    if (newText.length > 12) {
+      newText = newText.substring(0, 12);
+    }
+
+    StringBuffer formattedText = StringBuffer();
+    for (int i = 0; i < newText.length; i++) {
+      formattedText.write(newText[i]);
+      if ((i == 3 || i == 7) && i != newText.length - 1) {
+        formattedText.write(' '); // Add space after 4th and 8th digit
+      }
+    }
+
+    // Calculate the new cursor position
+    int selectionIndex = formattedText.length;
+
+    // If a space was just added, and the original cursor was at the end of a group,
+    // we might need to adjust the cursor to be after the space.
+    // This logic can be complex depending on how backspacing near spaces is handled.
+    // For simplicity, we'll place it at the end for now.
+    // A more sophisticated approach would track cursor movement more closely.
+
+    // ConsidernewValue.selection.end for more precise cursor placement if needed,
+    // especially when deleting characters.
+
+    // If the formatted text is "X X X X", cursor is at 1. oldValue "X", newValue "X "
+    // oldValue: "1234" newValue: "12345" -> formatted: "1234 5" (selection 6)
+    // oldValue: "1234 " newValue: "1234" (deleted space) -> formatted: "1234" (selection 4)
+
+    // This basic cursor adjustment attempts to keep it at the end or where it was
+    // relative to the digits.
+    int newSelectionOffset = newValue.selection.end;
+    int spacesBeforeCursor = 0;
+    for(int i=0; i< newValue.selection.end && i < formattedText.length; i++){
+        if(formattedText.toString()[i] == ' '){
+            spacesBeforeCursor++;
+        }
+    }
+    newSelectionOffset = newValue.selection.end + spacesBeforeCursor - (newValue.text.substring(0, newValue.selection.end).split(' ').length -1);
+
+    // Ensure selection offset is within bounds
+    if (newSelectionOffset > formattedText.length) {
+      newSelectionOffset = formattedText.length;
+    }
+
+
+    return TextEditingValue(
+      text: formattedText.toString(),
+      selection: TextSelection.collapsed(offset: newSelectionOffset),
+    );
+  }
+}


### PR DESCRIPTION
- Implemented `AppzFieldType.mobile`:
  - Displays a "+91" prefix.
  - Accepts 10-digit numeric input.
  - Includes specific validation for length and mandatory status.

- Implemented `AppzFieldType.aadhaar`:
  - Uses `AadhaarInputFormatter` for "XXXX XXXX XXXX" formatting.
  - Accepts 12-digit numeric input.
  - Includes specific validation for length and mandatory status.

- Implemented `AppzFieldType.mpin`:
  - Added `mpinLength` parameter (defaults to 4).
  - Renders as a row of individual input segments.
  - Supports single-digit input per segment, text obscuring.
  - Implements auto-focus advancement to the next segment on input.
  - Implements basic backspace navigation to the previous segment.
  - Aggregates segment values into the main controller.
  - Includes validation for length and mandatory status.

- Updated `AppzInputFieldExamplePage` to include and demonstrate these new field types in various configurations and states.
- All new field types derive base styling from `AppzStyleConfig`.
- Noted areas for future refinement in MPIN backspace behavior, specific styling keys for new types in `ui_config.json`, and centralized validation error state propagation.