### PR TITLE
Fix: Resolve 'Undefined name inputDecoration' in mobile field type

### DIFF
--- a/lib/components/appz_input_field/appz_input_field.dart
+++ b/lib/components/appz_input_field/appz_input_field.dart
@@ -406,7 +406,7 @@ class _AppzInputFieldState extends State<AppzInputField> {
       );
 
       // Adjust contentPadding for the TextFormField as prefix is now separate
-      final mobileInputDecoration = inputDecoration.copyWith(
+      final mobileInputDecoration = baseInputDecoration.copyWith( // Changed here
         contentPadding: EdgeInsets.symmetric(
           horizontal: style.paddingHorizontal / 2, // Reduced left padding
           vertical: style.paddingVertical


### PR DESCRIPTION
- Corrected the creation of `mobileInputDecoration` within the `AppzFieldType.mobile` rendering block in `appz_input_field.dart`.
- It now correctly uses `baseInputDecoration.copyWith(...)` ensuring it derives from the common base style decoration created by `_createBaseInputDecoration`.
- This fixes the scope issue that led to the 'Undefined name inputDecoration' error when rendering the mobile input field.