### PR TITLE
Feat: Refactor Aadhaar to use sub-widget & architectural setup

### DIFF
--- a/example/appz_input_field_example_page.dart
+++ b/example/appz_input_field_example_page.dart
@@ -1,4 +1,3 @@
-import 'package:apz_flutter_components/components/appz_input_field/appz_input_field_theme.dart';
 import 'package:flutter/material.dart';
 // Adjust path if your project structure is different for the imports below
 import '../lib/components/appz_input_field/appz_input_field.dart';

--- a/lib/components/appz_input_field/field_types/mobile_input_widget.dart
+++ b/lib/components/appz_input_field/field_types/mobile_input_widget.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../appz_input_field_enums.dart';
+import '../appz_style_config.dart';
+
+class MobileInputWidget extends StatefulWidget {
+  final AppzStateStyle currentStyle;
+  final TextEditingController mainController; // For the 10-digit number part
+  final FocusNode? mainFocusNode;
+  final bool isEnabled;
+  final String? hintText; // Hint for the number part
+  final String countryCode; // e.g., "+91"
+  final bool countryCodeEditable; // If true, country code is also an input
+  final ValueChanged<String>? onChanged; // Called with full number "+91XXXXXXXXXX"
+  final FormFieldValidator<String>? validator; // Validates the 10-digit number part primarily
+  final AppzInputValidationType validationType;
+
+
+  const MobileInputWidget({
+    super.key,
+    required this.currentStyle,
+    required this.mainController,
+    this.mainFocusNode,
+    required this.isEnabled,
+    this.hintText,
+    this.countryCode = "+91",
+    this.countryCodeEditable = false, // Default to fixed country code
+    this.onChanged,
+    this.validator,
+    required this.validationType,
+  });
+
+  @override
+  State<MobileInputWidget> createState() => _MobileInputWidgetState();
+}
+
+class _MobileInputWidgetState extends State<MobileInputWidget> {
+  // If countryCodeEditable is true, we'd need a controller for it too.
+  // For now, assuming fixed country code.
+
+  @override
+  Widget build(BuildContext context) {
+    // Placeholder UI for Mobile input (Country Code + Number)
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: widget.currentStyle.paddingHorizontal,
+        vertical: widget.currentStyle.paddingVertical / 2, // Adjust padding for Row
+      ),
+      decoration: BoxDecoration(
+        color: widget.currentStyle.backgroundColor,
+        borderRadius: BorderRadius.circular(widget.currentStyle.borderRadius),
+        border: Border.all(
+          color: widget.currentStyle.borderColor,
+          width: widget.currentStyle.borderWidth,
+        ),
+      ),
+      child: Row(
+        children: [
+          // Country Code
+          Padding(
+            padding: EdgeInsets.only(right: widget.currentStyle.paddingHorizontal / 2),
+            child: Text(
+              widget.countryCode,
+              style: TextStyle(
+                color: widget.isEnabled ? widget.currentStyle.textColor : widget.currentStyle.textColor.withOpacity(0.5),
+                fontFamily: widget.currentStyle.fontFamily,
+                fontSize: widget.currentStyle.fontSize,
+              ),
+            ),
+          ),
+          // Number Input
+          Expanded(
+            child: Text(
+              'Mobile Number Field Placeholder (10 digits)',
+               style: TextStyle(color: widget.currentStyle.textColor.withOpacity(0.5))
+            ), // Actual TextFormField will go here
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/components/appz_input_field/field_types/mpin_input_widget.dart
+++ b/lib/components/appz_input_field/field_types/mpin_input_widget.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import '../appz_input_field_enums.dart';
+import '../appz_style_config.dart';
+
+class MpinInputWidget extends StatefulWidget {
+  final AppzStateStyle currentStyle;
+  final TextEditingController mainController; // For the combined MPIN
+  final bool isEnabled;
+  final bool obscureText;
+  final int mpinLength;
+  final ValueChanged<String>? onChanged; // Called with combined mpin string
+  final FormFieldValidator<String>? validator; // Validates combined mpin string
+  final AppzInputValidationType validationType;
+
+
+  const MpinInputWidget({
+    super.key,
+    required this.currentStyle,
+    required this.mainController,
+    required this.isEnabled,
+    required this.obscureText,
+    required this.mpinLength,
+    this.onChanged,
+    this.validator,
+    required this.validationType,
+  });
+
+  @override
+  State<MpinInputWidget> createState() => _MpinInputWidgetState();
+}
+
+class _MpinInputWidgetState extends State<MpinInputWidget> {
+  late List<TextEditingController> _segmentControllers;
+  late List<FocusNode> _segmentFocusNodes;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeSegments();
+  }
+
+  void _initializeSegments() {
+    _segmentControllers = List.generate(
+      widget.mpinLength,
+      (index) => TextEditingController(),
+    );
+    _segmentFocusNodes = List.generate(
+      widget.mpinLength,
+      (index) => FocusNode(),
+    );
+
+    for (int i = 0; i < widget.mpinLength; i++) {
+      _segmentControllers[i].addListener(() => _onSegmentChanged(i));
+      // TODO: Add RawKeyboardListener or similar for better backspace handling if needed
+    }
+  }
+
+  void _disposeSegments() {
+    for (var controller in _segmentControllers) {
+      controller.dispose();
+    }
+    for (var focusNode in _segmentFocusNodes) {
+      focusNode.dispose();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant MpinInputWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.mpinLength != oldWidget.mpinLength) {
+      _disposeSegments();
+      _initializeSegments();
+    }
+    // TODO: Handle external changes like isEnabled if needed, though AppzInputField might just rebuild it.
+  }
+
+
+  void _onSegmentChanged(int segmentIndex) {
+    final currentValue = _segmentControllers[segmentIndex].text;
+
+    // Update main controller
+    String combinedValue = _segmentControllers.map((c) => c.text).join();
+    if (widget.mainController.text != combinedValue) {
+      widget.mainController.text = combinedValue;
+      widget.onChanged?.call(combinedValue);
+    }
+
+    if (!widget.isEnabled) return;
+
+    // Auto-focus next field
+    if (currentValue.isNotEmpty && segmentIndex < widget.mpinLength - 1) {
+      FocusScope.of(context).requestFocus(_segmentFocusNodes[segmentIndex + 1]);
+    }
+    // Backspace logic will be enhanced in the build method's TextFormField onChanged
+  }
+
+  @override
+  void dispose() {
+    _disposeSegments();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    // Placeholder - actual segment UI will be built here
+    // This will be a Row of small TextFormFields
+    return Container(
+       padding: EdgeInsets.symmetric(
+        horizontal: widget.currentStyle.paddingHorizontal,
+        vertical: widget.currentStyle.paddingVertical
+      ),
+      decoration: BoxDecoration(
+        // This container might not need its own border if segments are individually bordered
+        // Or it could provide an outer unified border
+        borderRadius: BorderRadius.circular(widget.currentStyle.borderRadius),
+        // border: Border.all(color: Colors.transparent), // Example: transparent outer border
+      ),
+      child: Center(child: Text('MPIN Input Widget Placeholder (${widget.mpinLength} segments)')),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apz_flutter_components
 description: "A reusable UI component library for Flutter."
-version: 0.0.6
+version: 0.0.2
 homepage: https://github.com/CHETHANK080300/APZ_FLUTTER_COMPONENTS.git
 
 environment:


### PR DESCRIPTION
- Established an architecture for using sub-widgets for complex field types within AppzInputField.
- Created `field_types` directory and placeholder files for `AadhaarInputWidget`, `MpinInputWidget`, and `MobileInputWidget`.
- Implemented `AadhaarInputWidget` with three 4-digit segments:
  - Manages internal controllers and focus nodes for each segment.
  - Handles auto-focus to the next segment and basic backspace navigation.
  - Aggregates segment values into the main controller.
  - Segments are styled based on the overall field state and AppzStyleConfig.
  - Supports enabled/disabled (readonly) mode.
- Updated `AppzInputField` to instantiate and use `AadhaarInputWidget` for `AppzFieldType.aadhaar`.
  - The main controller now receives the raw 12-digit Aadhaar string.
  - Validation logic in `AppzInputField` works on this combined string.
- Verified and updated the example page for the new segmented Aadhaar input.
- Ensured `AppzFieldState.disabled` is functioning correctly as a prerequisite.