### PR TITLE
Feat: Refactor Mobile field to two-part input (Phase 3C)

### DIFF
--- a/example/appz_input_field_example_page.dart
+++ b/example/appz_input_field_example_page.dart
@@ -130,11 +130,19 @@ class _AppzInputFieldExamplePageState extends State<AppzInputFieldExamplePage> {
               const Text("Mobile Number Input (+91 prefix, 10 digits):", style: TextStyle(fontWeight: FontWeight.bold)),
               AppzInputField(
                 label: 'Mobile Number',
-                hintText: '00000 00000',
-                controller: _mobileController,
+                hintText: 'Enter 10-digit number', // Hint for the number part
+                controller: _mobileController, // Will store "+91XXXXXXXXXX"
                 fieldType: AppzFieldType.mobile,
-                validationType: AppzInputValidationType.mandatory, // To make it required
-                // Internal validator in AppzInputField for mobile handles 10-digit check
+                // mobileCountryCode: "+91", // Default
+                validationType: AppzInputValidationType.mandatory,
+                validator: (numberPart) { // This validator receives ONLY the 10-digit number part
+                  if (numberPart != null && numberPart.startsWith('0')) {
+                    return 'Number should not start with 0.';
+                  }
+                  // Length (10) and mandatory are already checked by AppzInputField's internal logic
+                  // if this validator returns null.
+                  return null;
+                },
               ),
               const SizedBox(height: 20),
 

--- a/lib/components/appz_input_field/field_types/mobile_input_widget.dart
+++ b/lib/components/appz_input_field/field_types/mobile_input_widget.dart
@@ -5,29 +5,28 @@ import '../appz_style_config.dart';
 
 class MobileInputWidget extends StatefulWidget {
   final AppzStateStyle currentStyle;
-  final TextEditingController mainController; // For the 10-digit number part
-  final FocusNode? mainFocusNode;
+  final TextEditingController mainController; // Will store the full "+91XXXXXXXXXX"
+  final FocusNode? mainFocusNode; // Focus for the number input part
   final bool isEnabled;
   final String? hintText; // Hint for the number part
-  final String countryCode; // e.g., "+91"
-  final bool countryCodeEditable; // If true, country code is also an input
+  final String countryCode;
+  final bool countryCodeEditable; // Future: for editable country code
   final ValueChanged<String>? onChanged; // Called with full number "+91XXXXXXXXXX"
-  final FormFieldValidator<String>? validator; // Validates the 10-digit number part primarily
+  final FormFieldValidator<String>? validator; // Validates the 10-digit number part
   final AppzInputValidationType validationType;
-
 
   const MobileInputWidget({
     super.key,
     required this.currentStyle,
-    required this.mainController,
+    required this.mainController, // This controller is now for the full number
     this.mainFocusNode,
     required this.isEnabled,
     this.hintText,
     this.countryCode = "+91",
-    this.countryCodeEditable = false, // Default to fixed country code
+    this.countryCodeEditable = false,
     this.onChanged,
-    this.validator, // This validator is for the number part
-    required this.validationType, // Already present, just confirming
+    this.validator,
+    required this.validationType,
   });
 
   @override
@@ -35,45 +34,191 @@ class MobileInputWidget extends StatefulWidget {
 }
 
 class _MobileInputWidgetState extends State<MobileInputWidget> {
-  // If countryCodeEditable is true, we'd need a controller for it too.
-  // For now, assuming fixed country code.
+  late TextEditingController _numberController;
+  String _currentCountryCode = "";
+
+  @override
+  void initState() {
+    super.initState();
+    _currentCountryCode = widget.countryCode;
+    _numberController = TextEditingController();
+    _initializeNumberFromMainController();
+    _numberController.addListener(_onNumberChanged);
+
+    // Listen to main controller for external programmatic changes
+    widget.mainController.addListener(_onMainControllerChanged);
+  }
+
+  void _initializeNumberFromMainController() {
+    final fullText = widget.mainController.text;
+    if (fullText.startsWith(_currentCountryCode)) {
+      final numberPart = fullText.substring(_currentCountryCode.length);
+      if (_numberController.text != numberPart) {
+        _numberController.value = TextEditingValue(
+          text: numberPart,
+          selection: TextSelection.collapsed(offset: numberPart.length),
+        );
+      }
+    } else if (fullText.isNotEmpty && _currentCountryCode.isNotEmpty && !fullText.startsWith(_currentCountryCode)) {
+      // If main controller has text that doesn't start with current country code,
+      // assume it's just the number part (e.g. initialValue was just number)
+       if (_numberController.text != fullText) {
+        _numberController.value = TextEditingValue(
+          text: fullText, // Assume it's the number part
+          selection: TextSelection.collapsed(offset: fullText.length),
+        );
+         // Immediately update main controller to include country code
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          _updateMainController();
+        });
+      }
+    } else {
+        if (_numberController.text.isNotEmpty) _numberController.clear();
+    }
+  }
+
+  void _onMainControllerChanged() {
+    // If main controller changes externally, reflect it in the number part
+    // This prevents an infinite loop with _onNumberChanged
+    final fullText = widget.mainController.text;
+    String numberPart = "";
+    if (fullText.startsWith(_currentCountryCode)) {
+      numberPart = fullText.substring(_currentCountryCode.length);
+    } else if (fullText.isNotEmpty && _currentCountryCode.isNotEmpty && !fullText.startsWith(_currentCountryCode)){
+      // If it was set externally without country code, assume it's the number part
+      numberPart = fullText;
+      // It's tricky to auto-prefix here without knowing user intent / cursor.
+      // For now, this listener primarily updates number part if main controller has valid full number.
+    }
+
+    if (_numberController.text != numberPart) {
+      // Temporarily remove listener to prevent loop when setting text
+      _numberController.removeListener(_onNumberChanged);
+      _numberController.value = TextEditingValue(
+        text: numberPart,
+        selection: TextSelection.collapsed(offset: numberPart.length),
+      );
+      _numberController.addListener(_onNumberChanged);
+    }
+  }
+
+
+  void _onNumberChanged() {
+    _updateMainController();
+  }
+
+  void _updateMainController() {
+    final String fullMobileNumber = _currentCountryCode + _numberController.text;
+    if (widget.mainController.text != fullMobileNumber) {
+      widget.mainController.value = TextEditingValue(
+        text: fullMobileNumber,
+        selection: TextSelection.collapsed(offset: fullMobileNumber.length),
+      );
+      // The AppzInputField's own listener on _internalController (widget.mainController here)
+      // will call widget.onChanged from AppzInputField.
+      // So, no need to call widget.onChanged directly from here if AppzInputField handles it.
+      // However, the plan was for AppzInputField.onChanged to provide the full number.
+      // Let's ensure AppzInputField's onChanged is correctly called.
+      // The parent AppzInputField's _handleTextChange is already wired to its _internalController.
+      // So, updating widget.mainController.text here WILL trigger the parent's onChanged.
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant MobileInputWidget oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.mainController != oldWidget.mainController) {
+      oldWidget.mainController.removeListener(_onMainControllerChanged);
+      widget.mainController.addListener(_onMainControllerChanged);
+      _initializeNumberFromMainController(); // Update with new main controller value
+    }
+    if (widget.countryCode != oldWidget.countryCode) {
+        _currentCountryCode = widget.countryCode;
+        _updateMainController(); // Re-construct full number with new country code
+    }
+    // isEnabled and currentStyle changes are handled by parent rebuild
+  }
+
+  @override
+  void dispose() {
+    widget.mainController.removeListener(_onMainControllerChanged);
+    _numberController.removeListener(_onNumberChanged);
+    _numberController.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
-    // Placeholder UI for Mobile input (Country Code + Number)
+    final AppzStateStyle style = widget.currentStyle;
+
+    // This is the decoration for the number input part, should be borderless
+    final numberInputDecoration = InputDecoration(
+      hintText: widget.hintText ?? '00000 00000',
+      hintStyle: TextStyle(
+        color: style.textColor.withOpacity(0.5),
+        fontFamily: style.fontFamily,
+        fontSize: style.fontSize,
+      ),
+      border: InputBorder.none, // No border for the inner field
+      focusedBorder: InputBorder.none,
+      enabledBorder: InputBorder.none,
+      errorBorder: InputBorder.none,
+      disabledBorder: InputBorder.none,
+      focusedErrorBorder: InputBorder.none,
+      contentPadding: EdgeInsets.zero, // No extra padding inside the number field part
+      isDense: true, // Make it compact
+    );
+
     return Container(
       padding: EdgeInsets.symmetric(
-        horizontal: widget.currentStyle.paddingHorizontal,
-        vertical: widget.currentStyle.paddingVertical / 2, // Adjust padding for Row
+        horizontal: style.paddingHorizontal,
+        vertical: style.paddingVertical,
       ),
       decoration: BoxDecoration(
-        color: widget.currentStyle.backgroundColor,
-        borderRadius: BorderRadius.circular(widget.currentStyle.borderRadius),
+        color: widget.isEnabled ? style.backgroundColor : style.backgroundColor.withOpacity(0.5),
+        borderRadius: BorderRadius.circular(style.borderRadius),
         border: Border.all(
-          color: widget.currentStyle.borderColor,
-          width: widget.currentStyle.borderWidth,
+          color: style.borderColor,
+          width: style.borderWidth,
         ),
       ),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center, // Center items vertically in the Row
         children: [
           // Country Code
+          // TODO: Make country code part focusable/tappable if editable
           Padding(
-            padding: EdgeInsets.only(right: widget.currentStyle.paddingHorizontal / 2),
+            padding: const EdgeInsets.only(right: 8.0), // Spacing after country code
             child: Text(
-              widget.countryCode,
+              _currentCountryCode,
               style: TextStyle(
-                color: widget.isEnabled ? widget.currentStyle.textColor : widget.currentStyle.textColor.withOpacity(0.5),
-                fontFamily: widget.currentStyle.fontFamily,
-                fontSize: widget.currentStyle.fontSize,
+                color: widget.isEnabled ? style.textColor : style.textColor.withOpacity(0.5),
+                fontFamily: style.fontFamily,
+                fontSize: style.fontSize,
               ),
             ),
           ),
           // Number Input
           Expanded(
-            child: Text(
-              'Mobile Number Field Placeholder (10 digits)',
-               style: TextStyle(color: widget.currentStyle.textColor.withOpacity(0.5))
-            ), // Actual TextFormField will go here
+            child: TextFormField(
+              controller: _numberController,
+              focusNode: widget.mainFocusNode,
+              enabled: widget.isEnabled,
+              style: TextStyle(
+                color: widget.isEnabled ? style.textColor : style.textColor.withOpacity(0.5),
+                fontFamily: style.fontFamily,
+                fontSize: style.fontSize,
+              ),
+              decoration: numberInputDecoration,
+              keyboardType: TextInputType.phone,
+              inputFormatters: [
+                FilteringTextInputFormatter.digitsOnly,
+                LengthLimitingTextInputFormatter(10),
+              ],
+              validator: widget.validator, // This validator is for the 10-digit number part
+              // onChanged is handled by the controller listener (_onNumberChanged)
+              // onFieldSubmitted can be passed from parent if needed
+            ),
           ),
         ],
       ),


### PR DESCRIPTION
- Refactored `AppzFieldType.mobile` to use a dedicated `_MobileInputWidget`.
- `_MobileInputWidget` renders a country code (fixed "+91" for now) and a 10-digit number input field within a single unified styled container.
- `AppzInputField`'s main controller now stores the full mobile number string (e.g., "+91XXXXXXXXXX") for `mobile` type.
- The `onChanged` callback of `AppzInputField` for `mobile` type also provides the full string.
- `AppzInputField`'s `_performValidation` method for `mobile` type now extracts the 10-digit number part from the full string before calling the user-supplied validator (which expects the 10-digit number part).
- Built-in mandatory and 10-digit length validations are applied to the extracted number part after the user's validator.
- Added `mobileCountryCode` and `mobileCountryCodeEditable` parameters to `AppzInputField` (editable country code not yet implemented in UI).
- Updated `AppzInputFieldExamplePage` to reflect and test the new two-part mobile input field, its value handling, and validation.