### PR TITLE
Feat: Implement Country Code Dropdown for Mobile Field (Phase 3D)

### DIFF
--- a/example/appz_input_field_example_page.dart
+++ b/example/appz_input_field_example_page.dart
@@ -22,6 +22,7 @@ class _AppzInputFieldExamplePageState extends State<AppzInputFieldExamplePage> {
   final _aadhaarController = TextEditingController();
   final _mpinController4digit = TextEditingController();
   final _mpinController6digit = TextEditingController();
+  final _mobileWithDropdownController = TextEditingController();
 
 
   final _formKey = GlobalKey<FormState>();
@@ -38,6 +39,7 @@ class _AppzInputFieldExamplePageState extends State<AppzInputFieldExamplePage> {
     _aadhaarController.dispose();
     _mpinController4digit.dispose();
     _mpinController6digit.dispose();
+    _mobileWithDropdownController.dispose();
     super.dispose();
   }
 
@@ -141,6 +143,26 @@ class _AppzInputFieldExamplePageState extends State<AppzInputFieldExamplePage> {
                   }
                   // Length (10) and mandatory are already checked by AppzInputField's internal logic
                   // if this validator returns null.
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+
+              const Text("Mobile Number with Country Code Dropdown:", style: TextStyle(fontWeight: FontWeight.bold)),
+              AppzInputField(
+                label: 'Mobile (Dropdown)',
+                hintText: 'Enter number',
+                controller: _mobileWithDropdownController, // Will store "+XX...XXXXXXXXXX"
+                fieldType: AppzFieldType.mobile,
+                mobileCountryCodeEditable: true, // Enable dropdown
+                mobileCountryCode: "+1", // Start with US as example
+                validationType: AppzInputValidationType.mandatory,
+                validator: (numberPart) { // Receives only the number part after country code
+                  if (numberPart != null && numberPart.contains(RegExp(r'[^0-9]'))) {
+                    return 'Number part should only contain digits.';
+                  }
+                  // Length check will be handled by AppzInputField's internal validation for mobile
+                  // if this validator returns null and length is not 10.
                   return null;
                 },
               ),

--- a/lib/components/appz_input_field/utils/country_codes_helper.dart
+++ b/lib/components/appz_input_field/utils/country_codes_helper.dart
@@ -1,0 +1,36 @@
+import 'package:phonecodes/phonecodes.dart' as pc; // Using an alias to avoid conflict if any
+import 'country_model.dart';
+
+class CountryCodesHelper {
+  static List<CountryModel>? _countries;
+
+  static List<CountryModel> getCountries() {
+    if (_countries == null) {
+      _countries = pc.Country.values.map((country) {
+        return CountryModel(
+          isoCode: country.code, // Typically 2-letter ISO code
+          name: country.name,   // Full name of the country
+          phoneCode: country.dialCode.replaceAll('+', ''), // Store without '+'
+          flagEmoji: country.flag, // Emoji flag
+        );
+      }).toList();
+
+      // Optional: Sort by name or phone code if desired
+      _countries!.sort((a, b) => a.name.compareTo(b.name));
+    }
+    return _countries!;
+  }
+
+  static CountryModel? getCountryByDialCode(String dialCode) {
+    final String searchCode = dialCode.replaceAll('+', '');
+    try {
+      return getCountries().firstWhere((country) => country.phoneCode == searchCode);
+    } catch (e) {
+      return null; // Not found
+    }
+  }
+   static CountryModel getDefaultCountry() {
+    // Prioritize India, then US, then first in list as fallback
+    return getCountryByDialCode("91") ?? getCountryByDialCode("1") ?? getCountries().first;
+  }
+}

--- a/lib/components/appz_input_field/utils/country_model.dart
+++ b/lib/components/appz_input_field/utils/country_model.dart
@@ -1,0 +1,28 @@
+// Defines the data model for a country, used for country code selection.
+class CountryModel {
+  final String isoCode; // e.g., "IN"
+  final String name;    // e.g., "India"
+  final String phoneCode; // e.g., "91" (digits only)
+  final String flagEmoji; // e.g., "🇮🇳"
+
+  const CountryModel({
+    required this.isoCode,
+    required this.name,
+    required this.phoneCode,
+    required this.flagEmoji,
+  });
+
+  // For DropdownButtonFormField value comparison
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is CountryModel &&
+        other.isoCode == isoCode &&
+        other.phoneCode == phoneCode;
+  }
+
+  @override
+  int get hashCode => isoCode.hashCode ^ phoneCode.hashCode;
+
+  String get displayDialCode => "+${phoneCode}";
+}


### PR DESCRIPTION
- Added `CountryModel` and `CountryCodesHelper` (using `phonecodes` package) to manage and provide a list of country codes.
- Refactored `_MobileInputWidget`:
  - When `countryCodeEditable` is true, it now renders a `DropdownButtonFormField` for selecting country codes, displaying flag and dial code.
  - Manages `_selectedCountry` and synchronizes it with an internal number controller and the main `AppzInputField` controller (which stores the full '+XXXYYY...' number).
  - UI is a `Row` (dropdown/fixed code + number input) within a styled `Container` for a unified appearance.
- Updated `AppzInputField`:
  - `_performValidation` for mobile type now dynamically determines the current country code prefix from the full number string to correctly extract the 10-digit number part for validation.
  - The user-supplied validator for mobile fields now consistently receives only the 10-digit number part.
- Updated `AppzInputFieldExamplePage` to include and test the mobile field with the country code dropdown enabled, different initial country codes, and appropriate validation.